### PR TITLE
fix(globe_cli): Bad state no element error on deployment fixed

### DIFF
--- a/.github/.cspell/words_dictionary.txt
+++ b/.github/.cspell/words_dictionary.txt
@@ -1,2 +1,3 @@
 # Actual english words (or common abbreviations) missing from CSpell
 upvote
+archiver

--- a/packages/globe_cli/lib/src/commands/deploy_command.dart
+++ b/packages/globe_cli/lib/src/commands/deploy_command.dart
@@ -85,7 +85,8 @@ class DeployCommand extends BaseGlobeCommand {
           deploymentId: deployment.id,
         );
 
-        if (update.state == DeploymentState.working) {
+        if (update.state == DeploymentState.working ||
+            update.state == DeploymentState.deploying) {
           if (logs != null) return;
 
           status.complete();

--- a/packages/globe_cli/lib/src/commands/deploy_command.dart
+++ b/packages/globe_cli/lib/src/commands/deploy_command.dart
@@ -45,7 +45,7 @@ class DeployCommand extends BaseGlobeCommand {
 
     final validated = await scope.validate();
 
-    final deployProgess = logger.progress(
+    final deployProgress = logger.progress(
       'Deploying to ${styleBold.wrap('${validated.organization.slug}/${validated.project.slug}')}${environment == DeploymentEnvironment.production ? ' (production)' : ''}',
     );
 
@@ -63,7 +63,7 @@ class DeployCommand extends BaseGlobeCommand {
         archive: archive,
       );
 
-      deployProgess.complete();
+      deployProgress.complete();
 
       logger.success(
         '${lightGreen.wrap('✓')} Deployment has been queued',
@@ -149,11 +149,11 @@ class DeployCommand extends BaseGlobeCommand {
 
       return ExitCode.success.code;
     } on ApiException catch (e) {
-      deployProgess.fail();
+      deployProgress.fail();
       logger.err('✗ Failed to deploy project: ${e.message}');
       return ExitCode.software.code;
     } catch (e, s) {
-      deployProgess.fail();
+      deployProgress.fail();
       logger
         ..err('✗ Failed to deploy project: $e')
         ..err(s.toString());

--- a/packages/globe_cli/lib/src/commands/deploy_command.dart
+++ b/packages/globe_cli/lib/src/commands/deploy_command.dart
@@ -137,6 +137,13 @@ class DeployCommand extends BaseGlobeCommand {
           logger.info('Deployment cancelled');
         }
 
+        if (update.state == DeploymentState.invalid) {
+          status.complete();
+          status = logger.progress(
+            'Invalid Deployment State Received. Waiting for valid state',
+          );
+        }
+
         if (update.state == DeploymentState.success ||
             update.state == DeploymentState.cancelled ||
             update.state == DeploymentState.error) {

--- a/packages/globe_cli/lib/src/utils/api.dart
+++ b/packages/globe_cli/lib/src/utils/api.dart
@@ -466,6 +466,7 @@ class Deployment {
 enum DeploymentState {
   pending('Queued'),
   working('In progress'),
+  deploying('Deploying'),
   success('Deployment successful'),
   error('Deployment failed'),
   cancelled('Deployment cancelled');

--- a/packages/globe_cli/lib/src/utils/api.dart
+++ b/packages/globe_cli/lib/src/utils/api.dart
@@ -436,9 +436,13 @@ class Deployment {
           projectId: projectId,
           environment: DeploymentEnvironment.values.firstWhere(
             (e) => e.name == environment,
+            orElse: () => DeploymentEnvironment.invalid,
           ),
           status: status,
-          state: DeploymentState.values.firstWhere((e) => e.name == state),
+          state: DeploymentState.values.firstWhere(
+            (e) => e.name == state,
+            orElse: () => DeploymentState.invalid,
+          ),
           message: message ?? '',
           url: url,
           hash: hash,
@@ -469,7 +473,9 @@ enum DeploymentState {
   deploying('Deploying'),
   success('Deployment successful'),
   error('Deployment failed'),
-  cancelled('Deployment cancelled');
+  cancelled('Deployment cancelled'),
+  // state is not a valid state, but is used to represent an invalid state.
+  invalid('Invalid');
 
   const DeploymentState(this.message);
 
@@ -519,7 +525,8 @@ class FrameworkPresetOptions {
 
 enum DeploymentEnvironment {
   preview,
-  production;
+  production,
+  invalid;
 }
 
 enum Role {

--- a/packages/globe_cli/pubspec.lock
+++ b/packages/globe_cli/pubspec.lock
@@ -247,7 +247,7 @@ packages:
       path: "../globe_lints"
       relative: true
     source: path
-    version: "1.0.0"
+    version: "1.0.1"
   graphs:
     dependency: transitive
     description:


### PR DESCRIPTION
Cli was showing the following error output on the deploy command in the latest version (0.0.1+1)

<img width="1439" alt="Screenshot 2023-12-12 at 4 19 35 PM" src="https://github.com/invertase/globe/assets/10589266/54fec371-4ce3-4ecc-badb-c558f7821cad">

This PR fixes the bug

## Description

There was a missing state `deploying` that was added to the `DeploymentState` enum and log handling was also added.

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
