### PR TITLE
feat(globe_cli): Show build-log hint when deployment fails

### DIFF
--- a/packages/globe_cli/lib/src/commands/deploy_command.dart
+++ b/packages/globe_cli/lib/src/commands/deploy_command.dart
@@ -109,7 +109,7 @@ class DeployCommand extends BaseGlobeCommand {
               case DeploymentState.error:
                 status.fail(update.state.message);
                 logger.info(
-                  'Use globe build-logs --deployment="${deployment.id}" to view the build logs',
+                  'Use ${lightCyan.wrap('globe build-logs --deployment="${deployment.id}"')}  to view the build logs',
                 );
                 timer.cancel();
                 completer.complete();

--- a/packages/globe_cli/lib/src/commands/deploy_command.dart
+++ b/packages/globe_cli/lib/src/commands/deploy_command.dart
@@ -109,7 +109,7 @@ class DeployCommand extends BaseGlobeCommand {
               case DeploymentState.error:
                 status.fail(update.state.message);
                 logger.info(
-                  'Use globe build-logs --deployment="deploymentId" to view the build logs',
+                  'Use globe build-logs --deployment="${deployment.id}" to view the build logs',
                 );
                 timer.cancel();
                 completer.complete();

--- a/packages/globe_cli/lib/src/commands/deploy_command.dart
+++ b/packages/globe_cli/lib/src/commands/deploy_command.dart
@@ -108,6 +108,9 @@ class DeployCommand extends BaseGlobeCommand {
                 completer.complete();
               case DeploymentState.error:
                 status.fail(update.state.message);
+                logger.info(
+                  'Use globe build-logs --deployment="deploymentId" to view the build logs',
+                );
                 timer.cancel();
                 completer.complete();
               case DeploymentState.cancelled:

--- a/packages/globe_cli/lib/src/commands/deploy_command.dart
+++ b/packages/globe_cli/lib/src/commands/deploy_command.dart
@@ -109,7 +109,7 @@ class DeployCommand extends BaseGlobeCommand {
               case DeploymentState.error:
                 status.fail(update.state.message);
                 logger.info(
-                  'Use ${lightCyan.wrap('globe build-logs --deployment="${deployment.id}"')}  to view the build logs',
+                  'Use ${lightCyan.wrap('globe build-logs --deployment="${deployment.id}"')} to view the build logs',
                 );
                 timer.cancel();
                 completer.complete();


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Resolves: https://github.com/invertase/dart_globe/issues/104

This PR shows `globe build-log` hint when deployment fails.
```shell
➜  shelf git:(feat/show-build-logs-hint) ✗ dart run ../../packages/globe_cli/bin/globe.dart deploy

✓ Deploying to codekeyz/zomato (2.9s)
✓ Deployment has been queued
🔍 View deployment: https://globe.dev/codekeyz/zomato/deployments/b7dd77ab-7ee6-4eb2-86cc-a7343704d70e
✓ Queued (7.0s)
✗ Deployment failed (43.7s)
Use globe build-logs --deployment="b7dd77ab-7ee6-4eb2-86cc-a7343704d70e" to view the build logs
```

<!--- Describe your changes in detail and provide screenshots of the output of the change if possible, e.g. screenshot of the CLI output. -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
