### PR TITLE
feat(globe_cli): Added login url in output of login command

### DIFF
--- a/packages/globe_cli/lib/src/commands/login_command.dart
+++ b/packages/globe_cli/lib/src/commands/login_command.dart
@@ -40,8 +40,10 @@ class LoginCommand extends BaseGlobeCommand {
       onConnected: (port) async {
         logger.info('Please authenticate via the opened browser window.');
         // TODO can we react to openUrl close, to have the command emit a "failed to login"?
+        final url = '$endpoint/login/cli?callback=http://localhost:$port/callback?strategy=${GlobeHttpServerRedirectStrategy.redirect.name}';
+        logger.info('\nOr go to this link: $url\n');
         await openUrl(
-          '$endpoint/login/cli?callback=http://localhost:$port/callback?strategy=${GlobeHttpServerRedirectStrategy.redirect.name}',
+          url,
         );
       },
     );

--- a/packages/globe_cli/lib/src/commands/login_command.dart
+++ b/packages/globe_cli/lib/src/commands/login_command.dart
@@ -40,7 +40,8 @@ class LoginCommand extends BaseGlobeCommand {
       onConnected: (port) async {
         logger.info('Please authenticate via the opened browser window.');
         // TODO can we react to openUrl close, to have the command emit a "failed to login"?
-        final url = '$endpoint/login/cli?callback=http://localhost:$port/callback?strategy=${GlobeHttpServerRedirectStrategy.redirect.name}';
+        final url =
+            '$endpoint/login/cli?callback=http://localhost:$port/callback?strategy=${GlobeHttpServerRedirectStrategy.redirect.name}';
         logger.info('\nOr go to this link: $url\n');
         await openUrl(
           url,

--- a/packages/globe_cli/lib/src/utils/open_url.dart
+++ b/packages/globe_cli/lib/src/utils/open_url.dart
@@ -25,8 +25,7 @@ String get _openUrlCommand {
     return 'open';
   } else {
     throw UnsupportedError(
-      'Operating system not supported by the open_url '
-      'package: ${Platform.operatingSystem}',
+      'Operating system not supported: ${Platform.operatingSystem}',
     );
   }
 }

--- a/packages/globe_cli/test/login_test.dart
+++ b/packages/globe_cli/test/login_test.dart
@@ -58,7 +58,7 @@ void main() {
         ),
       );
 
-      final url =
+      const url =
           'https://globe.dev/login/cli?callback=http://localhost:4242/callback?strategy=redirect';
 
       await expectLater(
@@ -115,7 +115,7 @@ void main() {
         ),
       );
 
-      final url =
+      const url =
           'https://globe.dev/login/cli?callback=http://localhost:4242/callback?strategy=redirect';
 
       await expectLater(

--- a/packages/globe_cli/test/login_test.dart
+++ b/packages/globe_cli/test/login_test.dart
@@ -58,10 +58,15 @@ void main() {
         ),
       );
 
+      final url = 'https://globe.dev/login/cli?callback=http://localhost:4242/callback?strategy=redirect';
+
       await expectLater(
         result.testOutputByLines,
         emitsInOrder([
           'Please authenticate via the opened browser window.',
+          '',
+          'Or go to this link: $url',
+          '',
           'Successfully logged in.',
           emitsDone,
         ]),
@@ -69,7 +74,7 @@ void main() {
 
       verify(
         openUrlMock(
-          'https://globe.dev/login/cli?callback=http://localhost:4242/callback?strategy=redirect',
+          url,
         ),
       ).called(1);
       verifyNoMoreInteractions(openUrlMock);
@@ -109,10 +114,15 @@ void main() {
         ),
       );
 
+      final url = 'https://globe.dev/login/cli?callback=http://localhost:4242/callback?strategy=redirect';
+
       await expectLater(
         result.testOutputByLines,
         emitsInOrder([
           'Please authenticate via the opened browser window.',
+          '',
+          'Or go to this link: $url',
+          '',
           'err: Failed to login.',
           emitsDone,
         ]),
@@ -120,7 +130,7 @@ void main() {
 
       verify(
         openUrlMock(
-          'https://globe.dev/login/cli?callback=http://localhost:4242/callback?strategy=redirect',
+          url,
         ),
       ).called(1);
       verifyNoMoreInteractions(openUrlMock);

--- a/packages/globe_cli/test/login_test.dart
+++ b/packages/globe_cli/test/login_test.dart
@@ -58,7 +58,8 @@ void main() {
         ),
       );
 
-      final url = 'https://globe.dev/login/cli?callback=http://localhost:4242/callback?strategy=redirect';
+      final url =
+          'https://globe.dev/login/cli?callback=http://localhost:4242/callback?strategy=redirect';
 
       await expectLater(
         result.testOutputByLines,
@@ -114,7 +115,8 @@ void main() {
         ),
       );
 
-      final url = 'https://globe.dev/login/cli?callback=http://localhost:4242/callback?strategy=redirect';
+      final url =
+          'https://globe.dev/login/cli?callback=http://localhost:4242/callback?strategy=redirect';
 
       await expectLater(
         result.testOutputByLines,


### PR DESCRIPTION
## Description

Added a line of text in the output of the login command to show the url that will be opened in the browser so that the user can manually login by going to the url. Closes #25 

## Type of Change

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
