### PR TITLE
fix: Correctly handle windows path separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2024-02-27
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`globe_cli` - `v0.0.9-dev.1`](#globe_cli---v009-dev1)
+
+---
+
+#### `globe_cli` - `v0.0.9-dev.1`
+
+ - **FIX**: correctly join paths on windows. ([72e82463](https://github.com/invertase/globe/commit/72e824631d5a50386dcb4e59c23007e30f8dd8ab))
+
+
 ## 2024-02-26
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@ Packages with breaking changes:
 
 Packages with other changes:
 
+ - [`globe_cli` - `v0.0.9-dev.0+1`](#globe_cli---v009-dev01)
+
+---
+
+#### `globe_cli` - `v0.0.9-dev.0+1`
+
+ - **FIX**: correctly handle windows path separators. ([e9bcd44b](https://github.com/invertase/globe/commit/e9bcd44ba9dce8c6b7ea49d266a1c9a6cf68f59d))
+
+
+## 2024-02-26
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
  - [`globe_cli` - `v0.0.9`](#globe_cli---v009)
 
 ---

--- a/packages/globe_cli/CHANGELOG.md
+++ b/packages/globe_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.9-dev.0+1
+
+ - **FIX**: correctly handle windows path separators. ([e9bcd44b](https://github.com/invertase/globe/commit/e9bcd44ba9dce8c6b7ea49d266a1c9a6cf68f59d))
+
 ## 0.0.9
 
  - **FIX**: Remove need for scope validation ([#49](https://github.com/invertase/globe/issues/49)). ([cc0e715d](https://github.com/invertase/globe/commit/cc0e715da731585dc3fcb03ec8caf6e29af6308d))

--- a/packages/globe_cli/CHANGELOG.md
+++ b/packages/globe_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.9-dev.1
+
+ - **FIX**: correctly join paths on windows. ([72e82463](https://github.com/invertase/globe/commit/72e824631d5a50386dcb4e59c23007e30f8dd8ab))
+
 ## 0.0.9-dev.0+1
 
  - **FIX**: correctly handle windows path separators. ([e9bcd44b](https://github.com/invertase/globe/commit/e9bcd44ba9dce8c6b7ea49d266a1c9a6cf68f59d))

--- a/packages/globe_cli/lib/src/package_info.dart
+++ b/packages/globe_cli/lib/src/package_info.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE. DO NOT EDIT BY HAND.
 
 const name = 'globe_cli';
-const version = '0.0.9';
+const version = '0.0.9-dev.0+1';
 const description = 'Globe CLI';
 const executable = 'globe';

--- a/packages/globe_cli/lib/src/package_info.dart
+++ b/packages/globe_cli/lib/src/package_info.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE. DO NOT EDIT BY HAND.
 
 const name = 'globe_cli';
-const version = '0.0.9-dev.0+1';
+const version = '0.0.9-dev.1';
 const description = 'Globe CLI';
 const executable = 'globe';

--- a/packages/globe_cli/lib/src/utils/archiver.dart
+++ b/packages/globe_cli/lib/src/utils/archiver.dart
@@ -85,7 +85,8 @@ Future<List<int>> zipDir(Directory directory) async {
 
   if (archive.isEmpty) {
     throw Exception(
-        'Archive appears to be empty. This may be a bug, please report on GitHub.');
+      'Archive appears to be empty. This may be a bug, please report on GitHub.',
+    );
   }
 
   final encoded = TarEncoder().encode(archive);

--- a/packages/globe_cli/lib/src/utils/archiver.dart
+++ b/packages/globe_cli/lib/src/utils/archiver.dart
@@ -7,10 +7,14 @@ import 'package:pool/pool.dart';
 
 /// Creates a zip archive of the given [directory].
 Future<List<int>> zipDir(Directory directory) async {
-  final directoryPath = p.join(directory.path, p.separator);
+  // NOTE: We can't use p.join here due to https://github.com/dart-lang/path/issues/37
+  // being present on Windows.
+  final directoryPath = directory.path + p.separator;
+
   final archive = Archive();
   final files = directory.listSync(recursive: true);
 
+  // Find all nested .gitignore files in the project.
   final gitignoreFiles = files
       .where((entity) => entity is File && entity.path.endsWith('.gitignore'))
       .map((entity) => File(entity.path));

--- a/packages/globe_cli/pubspec.yaml
+++ b/packages/globe_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: globe_cli
 description: Globe CLI
-version: 0.0.9-dev.0+1
+version: 0.0.9-dev.1
 repository: https://github.com/invertase/globe
 
 environment:

--- a/packages/globe_cli/pubspec.yaml
+++ b/packages/globe_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: globe_cli
 description: Globe CLI
-version: 0.0.9
+version: 0.0.9-dev.0+1
 repository: https://github.com/invertase/globe
 
 environment:


### PR DESCRIPTION
## Description

Fixes: https://discord.com/channels/1179425190007021568/1210461084352389240

On windows, I think the uploaded archive is empty due to the path separator being incorrect.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
