### PR TITLE
fix(globe_cli): Auth required before token checked bug

### DIFF
--- a/packages/globe_cli/lib/src/commands/deploy_command.dart
+++ b/packages/globe_cli/lib/src/commands/deploy_command.dart
@@ -52,8 +52,6 @@ class DeployCommand extends BaseGlobeCommand {
 
   @override
   Future<int> run() async {
-    requireAuth();
-
     if (argResults?['token'] != null && argResults?['project'] != null) {
       final token = argResults!['token'] as String;
       final project = argResults!['project'] as String;
@@ -70,6 +68,8 @@ class DeployCommand extends BaseGlobeCommand {
       }
 
       scope.setScope(orgId: organizations.first.id, projectId: project);
+    } else {
+      requireAuth();
     }
 
     // If there is no scope, ask the user to link the project.


### PR DESCRIPTION
## Description

This fixes a bug where deploy with cli token does not work if logged out or in CI environment because the auth check was happening before token check.

## Type of Change


- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
