### PR TITLE
feat(globe_cli): Paused project handle for deploy and build log

### DIFF
--- a/packages/globe_cli/lib/src/utils/api.dart
+++ b/packages/globe_cli/lib/src/utils/api.dart
@@ -432,12 +432,29 @@ class Project {
     required this.id,
     required this.orgId,
     required this.slug,
+    required this.paused,
     required this.createdAt,
     required this.updatedAt,
   });
 
   factory Project.fromJson(Map<dynamic, dynamic> json) {
     return switch (json) {
+      {
+        'id': final String id,
+        'organizationId': final String organizationId,
+        'slug': final String slug,
+        'paused': final bool paused,
+        'createdAt': final String createdAt,
+        'updatedAt': final String updatedAt,
+      } =>
+        Project._(
+          id: id,
+          orgId: organizationId,
+          slug: slug,
+          paused: paused,
+          createdAt: DateTime.parse(createdAt),
+          updatedAt: DateTime.parse(updatedAt),
+        ),
       {
         'id': final String id,
         'organizationId': final String organizationId,
@@ -449,6 +466,7 @@ class Project {
           id: id,
           orgId: organizationId,
           slug: slug,
+          paused: false,
           createdAt: DateTime.parse(createdAt),
           updatedAt: DateTime.parse(updatedAt),
         ),
@@ -459,6 +477,7 @@ class Project {
   final String id;
   final String orgId;
   final String slug;
+  final bool paused;
   final DateTime createdAt;
   final DateTime updatedAt;
 }

--- a/packages/globe_cli/lib/src/utils/scope.dart
+++ b/packages/globe_cli/lib/src/utils/scope.dart
@@ -78,6 +78,13 @@ class GlobeScope {
           'Either that project does not exists or you do not have permission to access to it.',
         ),
       );
+
+      if (project.paused) {
+        throw Exception(
+          'Project #${metadata.projectId} is paused. '
+          'So, new deployments cannot be created for this project.',
+        );
+      }
     } on ApiException catch (e) {
       logger.err(e.message);
       exitOverride(1);


### PR DESCRIPTION
## Description

The CLI will give an error if the user tries to deploy paused project.

<img width="1387" alt="Screenshot 2024-04-02 at 6 33 54 PM" src="https://github.com/invertase/globe/assets/10589266/90e71dc9-0cbc-4b68-b66f-f85d3879ca54">

For the Project serialize logic, I added a new condition because in the near future we will refactor paused out of it and at that time it will not be a breaking change.

## Type of Change

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
