### PR TITLE
feat: Add `--project` and `--org` options on commands that depend on "scope".

### DIFF
--- a/examples/flutter_web/pubspec.lock
+++ b/examples/flutter_web/pubspec.lock
@@ -79,26 +79,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -119,18 +119,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -188,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   vector_math:
     dependency: transitive
     description:
@@ -204,9 +204,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.4"
 sdks:
-  dart: ">=3.2.0-0 <4.0.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/packages/globe_cli/lib/src/command.dart
+++ b/packages/globe_cli/lib/src/command.dart
@@ -22,6 +22,8 @@ typedef RunProcess = Future<ProcessResult> Function(
   bool runInShell,
 });
 
+typedef ScopeValidator = Future<ScopeValidation> Function();
+
 abstract class BaseGlobeCommand extends Command<int> {
   GlobeAuth get auth => GetIt.I();
   GlobeApi get api => GetIt.I();
@@ -41,5 +43,23 @@ abstract class BaseGlobeCommand extends Command<int> {
     }
 
     // TODO(ehesp): Check for JWT expiry and refresh if needed?
+  }
+
+  ScopeValidator declareScopeArguments() {
+    argParser
+      ..addOption(
+        'org',
+        abbr: 'o',
+        help: 'The organization ID used by this command. '
+            'Defaults to what was previously linked using `globe link`.',
+      )
+      ..addOption(
+        'project',
+        abbr: 'p',
+        help: 'The Project ID used by this command. '
+            'Defaults to what was previously linked using `globe link`.',
+      );
+
+    return () => scope.validate(argResults);
   }
 }

--- a/packages/globe_cli/lib/src/command_runner.dart
+++ b/packages/globe_cli/lib/src/command_runner.dart
@@ -2,7 +2,6 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:cli_completion/cli_completion.dart';
 import 'package:get_it/get_it.dart';
-import 'package:globe_cli/src/get_it.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:pub_updater/pub_updater.dart';
 
@@ -11,6 +10,7 @@ import 'commands/commands.dart';
 import 'commands/create_project_command.dart';
 import 'commands/project_command.dart';
 import 'commands/update.dart';
+import './get_it.dart';
 import 'package_info.dart' as package_info;
 import 'utils/api.dart';
 import 'utils/auth.dart';

--- a/packages/globe_cli/lib/src/command_runner.dart
+++ b/packages/globe_cli/lib/src/command_runner.dart
@@ -2,6 +2,7 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:cli_completion/cli_completion.dart';
 import 'package:get_it/get_it.dart';
+import 'package:globe_cli/src/get_it.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:pub_updater/pub_updater.dart';
 
@@ -93,19 +94,18 @@ class GlobeCliCommandRunner extends CompletionCommandRunner<int> {
         await _checkForUpdates();
       }
 
-      final auth = GlobeAuth(metadata);
-      final api = GlobeApi(
-        metadata: metadata,
-        auth: auth,
-        logger: _logger,
+      final auth = GetIt.instance.singletonPutIfAbsent<GlobeAuth>(
+        () => GlobeAuth(metadata),
       );
+      final api = GetIt.instance.singletonPutIfAbsent<GlobeApi>(() {
+        return GlobeApi(metadata: metadata, auth: auth, logger: _logger);
+      });
       final scope = GlobeScope(
         api: api,
         metadata: metadata,
         logger: _logger,
       );
-      GetIt.instance.registerSingleton<GlobeAuth>(auth);
-      GetIt.instance.registerSingleton<GlobeApi>(api);
+
       GetIt.instance.registerSingleton<GlobeMetadata>(metadata);
       GetIt.instance.registerSingleton<GlobeScope>(scope);
 

--- a/packages/globe_cli/lib/src/command_runner.dart
+++ b/packages/globe_cli/lib/src/command_runner.dart
@@ -10,7 +10,7 @@ import 'commands/commands.dart';
 import 'commands/create_project_command.dart';
 import 'commands/project_command.dart';
 import 'commands/update.dart';
-import './get_it.dart';
+import 'get_it.dart';
 import 'package_info.dart' as package_info;
 import 'utils/api.dart';
 import 'utils/auth.dart';

--- a/packages/globe_cli/lib/src/commands/build_logs_command.dart
+++ b/packages/globe_cli/lib/src/commands/build_logs_command.dart
@@ -10,7 +10,10 @@ class BuildLogsCommand extends BaseGlobeCommand {
       abbr: 'd',
       help: 'Deployment ID.',
     );
+    _validator = declareScopeArguments();
   }
+
+  late final ScopeValidator _validator;
 
   @override
   String get description => 'View build logs for a given deployment ID.';
@@ -22,11 +25,7 @@ class BuildLogsCommand extends BaseGlobeCommand {
   Future<int> run() async {
     requireAuth();
 
-    if (!scope.hasScope()) {
-      logger.err('Not a Globe project.');
-    }
-
-    final validated = await scope.validate();
+    final validated = await _validator();
     final deploymentId = argResults!['deployment'] as String?;
 
     if (deploymentId == null) {

--- a/packages/globe_cli/lib/src/commands/deploy_command.dart
+++ b/packages/globe_cli/lib/src/commands/deploy_command.dart
@@ -31,13 +31,9 @@ class DeployCommand extends BaseGlobeCommand {
         'token',
         abbr: 't',
         help: 'Set the API token for deployment. Also needs --project',
-      )
-      ..addOption(
-        'project',
-        abbr: 'p',
-        help:
-            'Set the project for deployment with API token. Used with --token',
       );
+
+    _validator = declareScopeArguments();
   }
 
   @override
@@ -49,6 +45,8 @@ class DeployCommand extends BaseGlobeCommand {
   DeploymentEnvironment get environment => argResults!['prod'] as bool
       ? DeploymentEnvironment.production
       : DeploymentEnvironment.preview;
+
+  late final ScopeValidator _validator;
 
   @override
   Future<int> run() async {
@@ -77,7 +75,7 @@ class DeployCommand extends BaseGlobeCommand {
       await linkProject(logger: logger, api: api);
     }
 
-    final validated = await scope.validate();
+    final validated = await _validator();
     if (validated.project.paused) {
       logger
         ..err('No new deployments can be created for this project.')

--- a/packages/globe_cli/lib/src/commands/project/project_pause_command.dart
+++ b/packages/globe_cli/lib/src/commands/project/project_pause_command.dart
@@ -6,21 +6,23 @@ import '../../command.dart';
 import '../../utils/api.dart';
 
 class ProjectPauseCommand extends BaseGlobeCommand {
+  ProjectPauseCommand() {
+    _validator = declareScopeArguments();
+  }
+
   @override
   String get description => 'Pause the current globe project';
 
   @override
   String get name => 'pause';
 
+  late final ScopeValidator _validator;
+
   @override
   FutureOr<int> run() async {
     requireAuth();
 
-    if (!scope.hasScope()) {
-      logger.err('Not a Globe project.');
-    }
-
-    final validated = await scope.validate();
+    final validated = await _validator();
     final projectSlug = validated.project.slug;
     final pauseProjectProgress =
         logger.progress('Pausing project: ${cyan.wrap(projectSlug)}');

--- a/packages/globe_cli/lib/src/commands/project/project_resume_command.dart
+++ b/packages/globe_cli/lib/src/commands/project/project_resume_command.dart
@@ -6,21 +6,23 @@ import '../../command.dart';
 import '../../utils/api.dart';
 
 class ProjectResumeCommand extends BaseGlobeCommand {
+  ProjectResumeCommand() {
+    _validator = declareScopeArguments();
+  }
+
   @override
   String get description => 'Resume the current globe project';
 
   @override
   String get name => 'resume';
 
+  late final ScopeValidator _validator;
+
   @override
   FutureOr<int> run() async {
     requireAuth();
 
-    if (!scope.hasScope()) {
-      logger.err('Not a Globe project.');
-    }
-
-    final validated = await scope.validate();
+    final validated = await _validator();
     final projectSlug = validated.project.slug;
     final pauseProjectProgress =
         logger.progress('Resuming project: ${cyan.wrap(projectSlug)}');

--- a/packages/globe_cli/lib/src/get_it.dart
+++ b/packages/globe_cli/lib/src/get_it.dart
@@ -1,0 +1,15 @@
+import 'package:get_it/get_it.dart';
+
+extension GetItX on GetIt {
+  /// Initialize a singleton if it is not already registered.
+  ///
+  /// This is mainly useful for tests, where tests register overrides
+  /// for singletons.
+  T singletonPutIfAbsent<T extends Object>(T Function() value) {
+    if (!isRegistered<T>()) {
+      registerSingleton<T>(value());
+    }
+
+    return get<T>();
+  }
+}

--- a/packages/globe_cli/lib/src/utils/api.dart
+++ b/packages/globe_cli/lib/src/utils/api.dart
@@ -408,7 +408,7 @@ class SettingsConnection {
 }
 
 class Organization {
-  Organization._({
+  Organization({
     required this.id,
     required this.name,
     required this.slug,
@@ -429,7 +429,7 @@ class Organization {
         'createdAt': final String createdAt,
         'updatedAt': final String updatedAt,
       } =>
-        Organization._(
+        Organization(
           id: id,
           name: name,
           slug: slug,
@@ -452,7 +452,7 @@ class Organization {
 }
 
 class Project {
-  Project._({
+  Project({
     required this.id,
     required this.orgId,
     required this.slug,
@@ -471,7 +471,7 @@ class Project {
         'createdAt': final String createdAt,
         'updatedAt': final String updatedAt,
       } =>
-        Project._(
+        Project(
           id: id,
           orgId: organizationId,
           slug: slug,
@@ -486,7 +486,7 @@ class Project {
         'createdAt': final String createdAt,
         'updatedAt': final String updatedAt,
       } =>
-        Project._(
+        Project(
           id: id,
           orgId: organizationId,
           slug: slug,

--- a/packages/globe_cli/lib/src/utils/prompts.dart
+++ b/packages/globe_cli/lib/src/utils/prompts.dart
@@ -48,7 +48,6 @@ Future<ScopeMetadata> linkProject({
       organization,
       logger: logger,
       api: api,
-      scope: scope,
     );
 
     final result = scope.setScope(
@@ -119,7 +118,6 @@ Future<Project> selectProject(
   Organization organization, {
   required Logger logger,
   required GlobeApi api,
-  required GlobeScope scope,
 }) async {
   logger.detail('Fetching organization projects');
   final projects = await api.getProjects(org: organization.id);

--- a/packages/globe_cli/lib/src/utils/scope.dart
+++ b/packages/globe_cli/lib/src/utils/scope.dart
@@ -2,13 +2,13 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:globe_cli/src/utils/prompts.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
 import '../exit.dart';
 import 'api.dart';
+import './prompts.dart';
 import 'metadata.dart';
 
 /// A utility class for managing the user's local project.
@@ -64,7 +64,7 @@ class GlobeScope {
     return organizations.firstWhere(
       (org) => org.id == orgId,
       orElse: () => throw Exception(
-        'Organization #${orgId} not found. '
+        'Organization #$orgId not found. '
         'Either that organization does not exists or you do not have permission to access to it.',
       ),
     );
@@ -76,14 +76,15 @@ class GlobeScope {
   ) async {
     final projectId = argResults?['project'] ?? current?.projectId;
 
-    if (projectId is! String)
+    if (projectId is! String) {
       return selectProject(org, logger: logger, api: api);
+    }
 
     final projects = await api.getProjects(org: org.id);
     return projects.firstWhere(
       (project) => project.id == projectId,
       orElse: () => throw Exception(
-        'Project #${projectId} not found. '
+        'Project #$projectId not found. '
         'Either that project does not exists or you do not have permission to access to it.',
       ),
     );

--- a/packages/globe_cli/lib/src/utils/scope.dart
+++ b/packages/globe_cli/lib/src/utils/scope.dart
@@ -8,7 +8,7 @@ import 'package:path/path.dart' as p;
 
 import '../exit.dart';
 import 'api.dart';
-import './prompts.dart';
+import 'prompts.dart';
 import 'metadata.dart';
 
 /// A utility class for managing the user's local project.

--- a/packages/globe_cli/lib/src/utils/scope.dart
+++ b/packages/globe_cli/lib/src/utils/scope.dart
@@ -8,8 +8,8 @@ import 'package:path/path.dart' as p;
 
 import '../exit.dart';
 import 'api.dart';
-import 'prompts.dart';
 import 'metadata.dart';
+import 'prompts.dart';
 
 /// A utility class for managing the user's local project.
 class GlobeScope {

--- a/packages/globe_cli/pubspec.lock
+++ b/packages/globe_cli/pubspec.lock
@@ -5,34 +5,39 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: ae92f5d747aee634b87f89d9946000c2de774be1d6ac3e58268224348cd0101a
+      sha256: "45cfa8471b89fb6643fe9bf51bd7931a76b8f5ec2d65de4fb176dba8d4f22c77"
       url: "https://pub.dev"
     source: hosted
-    version: "61.0.0"
+    version: "73.0.0"
+  _macros:
+    dependency: transitive
+    description: dart
+    source: sdk
+    version: "0.3.2"
   analyzer:
     dependency: "direct dev"
     description:
       name: analyzer
-      sha256: ea3d8652bda62982addfd92fdc2d0214e5f82e43325104990d4f4c4a2a313562
+      sha256: "4959fec185fe70cce007c57e9ab6983101dbe593d2bf8bbfb4453aaec0cf470a"
       url: "https://pub.dev"
     source: hosted
-    version: "5.13.0"
+    version: "6.8.0"
   archive:
     dependency: "direct main"
     description:
       name: archive
-      sha256: "0c8368c9b3f0abbc193b9d6133649a614204b528982bebc7026372d61677ce3a"
+      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.7"
+    version: "3.6.1"
   args:
     dependency: "direct main"
     description:
       name: args
-      sha256: "4cab82a83ffef80b262ddedf47a0a8e56ee6fbf7fe21e6e768b02792034dd440"
+      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.5.0"
   async:
     dependency: transitive
     description:
@@ -53,10 +58,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "43865b79fbb78532e4bff7c33087aa43b1d488c4fdef014eaef568af6d8016dc"
+      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   build_config:
     dependency: transitive
     description:
@@ -69,34 +74,34 @@ packages:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "5f02d73eb2ba16483e693f80bee4f088563a820e47d1027d4cdfe62b5bb43e65"
+      sha256: "79b2aef6ac2ed00046867ed354c88778c9c0f029df8a20fe10b5436826721ef9"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.2"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: db49b8609ef8c81cca2b310618c3017c00f03a92af44c04d310b907b2d692d95
+      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "5e1929ad37d48bd382b124266cb8e521de5548d406a45a5ae6656c13dab73e37"
+      sha256: "644dc98a0f179b872f612d3eb627924b578897c629788e858157fa5e704ca0c7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.5"
+    version: "2.4.11"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "30859c90e9ddaccc484f56303931f477b1f1ba2bab74aa32ed5d6ce15870f8cf"
+      sha256: e3c79f69a64bdfcd8a776a3c28db4eb6e3fb5356d013ae5eb2e52007706d5dbe
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.8"
+    version: "7.3.1"
   built_collection:
     dependency: transitive
     description:
@@ -109,10 +114,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "598a2a682e2a7a90f08ba39c0aaa9374c5112340f0a2e275f61b59389543d166"
+      sha256: c7913a9737ee4007efedaffc968c049fd0f3d0e49109e778edc10de9426005cb
       url: "https://pub.dev"
     source: hosted
-    version: "8.6.1"
+    version: "8.9.2"
   checked_yaml:
     dependency: transitive
     description:
@@ -133,26 +138,26 @@ packages:
     dependency: "direct main"
     description:
       name: cli_util
-      sha256: b8db3080e59b2503ca9e7922c3df2072cf13992354d5e944074ffa836fba43b7
+      sha256: c05b7406fdabc7a49a3929d4af76bcaccbbffcbcdcf185b082e1ae07da323d19
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.0"
+    version: "0.4.1"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "4ad01d6e56db961d29661561effde45e519939fdaeb46c351275b182eac70189"
+      sha256: f692079e25e7869c14132d39f223f8eec9830eb76131925143b2129c4bb01b37
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.0"
+    version: "4.10.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.19.0"
   convert:
     dependency: transitive
     description:
@@ -165,26 +170,26 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "2fb815080e44a09b85e0f2ca8a820b15053982b2e714b59267719e8a9ff17097"
+      sha256: "3945034e86ea203af7a056d98e98e42a5518fff200d6e8e6647e1886b07e936e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.3"
+    version: "1.8.0"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      sha256: f4f1f73ab3fd2afcbcca165ee601fe980d966af6a21b5970c6c9376955c528ad
+      sha256: "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.6"
   equatable:
     dependency: transitive
     description:
@@ -193,6 +198,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.5"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   file:
     dependency: "direct dev"
     description:
@@ -221,18 +234,18 @@ packages:
     dependency: transitive
     description:
       name: frontend_server_client
-      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "4.0.0"
   get_it:
     dependency: "direct main"
     description:
       name: get_it
-      sha256: "290fde3a86072e4b37dbb03c07bec6126f0ecc28dad403c12ffe2e5a2d751ab7"
+      sha256: d85128a5dae4ea777324730dc65edd9c9f43155c109d5cc0a69cab74139fbac1
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.0"
+    version: "7.7.0"
   glob:
     dependency: "direct main"
     description:
@@ -260,10 +273,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
+      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.5"
+    version: "0.13.6"
   http_multi_server:
     dependency: transitive
     description:
@@ -276,10 +289,10 @@ packages:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      sha256: "40f592dd352890c3b60fec1b68e786cefb9603e05ff303dbc4dda49b304ecdf4"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "4.1.0"
   io:
     dependency: transitive
     description:
@@ -292,18 +305,18 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.7.1"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
+      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.9.0"
   lints:
     dependency: transitive
     description:
@@ -320,46 +333,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  macros:
+    dependency: transitive
+    description:
+      name: macros
+      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2-main.4"
   mason_logger:
     dependency: "direct main"
     description:
       name: mason_logger
-      sha256: ca34d14e998cd7a7738e7320b102aa45fb363aa49a290084b211ababf75bb7ee
+      sha256: "1fdf5c76870eb6fc3611ed6fbae1973a3794abe581ea5e22e68af2f73c688b93"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.16"
   matcher:
     dependency: "direct dev"
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      sha256: "2e123074287cc9fd6c09de8336dae606d1ddb88d9ac47358826db698c176a1f2"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   mockito:
     dependency: "direct dev"
     description:
       name: mockito
-      sha256: "7d5b53bcd556c1bc7ffbe4e4d5a19c3e112b7e925e9e172dd7c6ad0630812616"
+      sha256: "6841eed20a7befac0ce07df8116c8b8233ed1f4486a7647c7fc5a02ae6163917"
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.2"
+    version: "5.4.4"
   node_preamble:
     dependency: transitive
     description:
@@ -380,26 +401,18 @@ packages:
     dependency: "direct main"
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   platform:
     dependency: "direct dev"
     description:
       name: platform
-      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
-  pointycastle:
-    dependency: transitive
-    description:
-      name: pointycastle
-      sha256: "7c1e5f0d23c9016c5bbd8b1473d0d3fb3fc851b876046039509e18e0c7485f2c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.7.3"
+    version: "3.1.5"
   pool:
     dependency: "direct main"
     description:
@@ -436,18 +449,18 @@ packages:
     dependency: "direct main"
     description:
       name: pubspec_parse
-      sha256: c63b2876e58e194e4b0828fcb080ad0e06d051cb607a6be51a9e084f47cb9367
+      sha256: c799b721d79eb6ee6fa56f00c04b472dcd44a30d258fac2174a6ec57302678f8
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
+    version: "1.3.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
+      sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.2"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -468,18 +481,18 @@ packages:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
+      sha256: "073c147238594ecd0d193f3456a5fe91c4b0abbcc68bf5cd95b36c4e194ac611"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.0"
   source_gen:
     dependency: transitive
     description:
       name: source_gen
-      sha256: fc0da689e5302edb6177fdd964efcb7f58912f43c28c2047a808f5bfff643d16
+      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -508,18 +521,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   stream_transform:
     dependency: transitive
     description:
@@ -532,10 +545,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
@@ -548,26 +561,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "13b41f318e2a5751c3169137103b60c584297353d4b1761b66029bae6411fe46"
+      sha256: "713a8789d62f3233c46b4a90b174737b2c04cb6ae4500f2aa8b1be8f03f5e67f"
       url: "https://pub.dev"
     source: hosted
-    version: "1.24.3"
+    version: "1.25.8"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.7.3"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "99806e9e6d95c7b059b7a0fc08f07fc53fabe54a829497f0d9676299f1e8637e"
+      sha256: "12391302411737c176b0b5d6491f466b0dd56d4763e347b6714efbaa74d7953d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.3"
+    version: "0.6.5"
   timing:
     dependency: transitive
     description:
@@ -580,18 +593,18 @@ packages:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f3743ca475e0c9ef71df4ba15eb2d7684eecd5c8ba20a462462e4e8b561b2e11
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "11.6.0"
+    version: "14.2.4"
   watcher:
     dependency: "direct dev"
     description:
@@ -600,22 +613,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: d43c1d6b787bf0afad444700ae7f4db8827f701bc61c255ac8d328c6f4d52062
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.6"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      sha256: "9f187088ed104edd8662ca07af4b124465893caf063ba29758f97af57e61da8f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "3.0.1"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: a79dbe579cb51ecd6d30b17e0cae4e0ea15e2c0e66f69ad4198f22a6789e94f4
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.5.1"
   yaml:
     dependency: transitive
     description:
@@ -625,4 +662,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"

--- a/packages/globe_cli/test/mock_helpers.dart
+++ b/packages/globe_cli/test/mock_helpers.dart
@@ -8,14 +8,18 @@ extension on Invocation {
 
 mixin MockMixin on Mock {
   Future<T> mockFuture<T>(Invocation invocation) async {
+    final voidFuture = Future<void>.value();
+
     return super.noSuchMethod(
       invocation,
-      returnValue:
-          Future<T>.error('Missing stub for ${invocation.getDisplayString()}')
-            ..ignore(),
-      returnValueForMissingStub:
-          Future<T>.error('Missing stub for ${invocation.getDisplayString()}')
-            ..ignore(),
+      returnValue: (voidFuture is Future<T>)
+          ? voidFuture
+          : Future<T>.error('Missing stub for ${invocation.getDisplayString()}')
+        ..ignore(),
+      returnValueForMissingStub: (voidFuture is Future<T>)
+          ? voidFuture
+          : Future<T>.error('Missing stub for ${invocation.getDisplayString()}')
+        ..ignore(),
     ) as Future<T>;
   }
 }

--- a/packages/globe_cli/test/mocks.dart
+++ b/packages/globe_cli/test/mocks.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:globe_cli/src/utils/api.dart';
 import 'package:globe_cli/src/utils/http_server.dart';
 import 'package:globe_cli/src/utils/open_url.dart';
 import 'package:mason_logger/mason_logger.dart';
@@ -101,5 +102,30 @@ class HttpClientMock extends Mock with MockMixin implements HttpClient {
   @override
   Future<HttpClientRequest> openUrl(String? method, Uri? url) {
     return mockFuture(Invocation.method(#openUrl, [method, url]));
+  }
+}
+
+class GlobeApiMock extends Mock with MockMixin implements GlobeApi {
+  @override
+  Future<List<Organization>> getOrganizations() {
+    return mockFuture(Invocation.method(#getOrganizations, []));
+  }
+
+  @override
+  Future<List<Project>> getProjects({required String? org}) {
+    return mockFuture(Invocation.method(#getProjects, [], {#org: org}));
+  }
+
+  @override
+  Future<void> resumeProject({
+    required String? orgId,
+    required String? projectId,
+  }) {
+    return mockFuture(
+      Invocation.method(#resumeProject, [], {
+        #orgId: orgId,
+        #projectId: projectId,
+      }),
+    );
   }
 }

--- a/packages/globe_cli/test/project/project_resume_command_test.dart
+++ b/packages/globe_cli/test/project/project_resume_command_test.dart
@@ -1,0 +1,64 @@
+import 'package:get_it/get_it.dart';
+import 'package:globe_cli/src/utils/api.dart';
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import '../mocks.dart';
+import '../test_utils.dart';
+import '../workspace.dart';
+import '../../bin/globe.dart' as globe;
+
+void main() {
+  setUp(() => GetIt.I.reset());
+
+  group('ProjectResumeCommand', () {
+    test('supports --project/--org', () async {
+      final workspace = TestWorkspace()..setRemoteAuthFile('{"jwt": "foo"}');
+      final pubUpdater = PubUpdaterMock(isUpToDate: () async => true);
+      final api = GlobeApiMock();
+
+      when(api.getOrganizations()).thenAnswer((i) async {
+        return [
+          Organization(
+            createdAt: DateTime.now(),
+            id: 'bar',
+            name: 'bar',
+            slug: 'bar',
+            updatedAt: DateTime.now(),
+            type: OrganizationType.personal,
+          )
+        ];
+      });
+      when(api.getProjects(org: 'bar')).thenAnswer((i) async {
+        return [
+          Project(
+            createdAt: DateTime.now(),
+            id: 'foo',
+            slug: 'foo',
+            paused: false,
+            orgId: 'bar',
+            updatedAt: DateTime.now(),
+          )
+        ];
+      });
+
+      GetIt.I.registerSingleton<GlobeApi>(api);
+
+      final result = runWithIOOverrides(
+        fs: workspace.fs,
+        () => globe.main(
+          ['project', 'resume', '--project=foo', '--org=bar'],
+          pubUpdater: pubUpdater,
+        ),
+      );
+
+      await result.exitCode;
+
+      await expectLater(
+        result.exitCode,
+        completion(ExitCode.success.code),
+      );
+    });
+  });
+}

--- a/packages/globe_cli/test/project/project_resume_command_test.dart
+++ b/packages/globe_cli/test/project/project_resume_command_test.dart
@@ -4,10 +4,10 @@ import 'package:mason_logger/mason_logger.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
+import '../../bin/globe.dart' as globe;
 import '../mocks.dart';
 import '../test_utils.dart';
 import '../workspace.dart';
-import '../../bin/globe.dart' as globe;
 
 void main() {
   setUp(() => GetIt.I.reset());
@@ -27,7 +27,7 @@ void main() {
             slug: 'bar',
             updatedAt: DateTime.now(),
             type: OrganizationType.personal,
-          )
+          ),
         ];
       });
       when(api.getProjects(org: 'bar')).thenAnswer((i) async {
@@ -39,7 +39,7 @@ void main() {
             paused: false,
             orgId: 'bar',
             updatedAt: DateTime.now(),
-          )
+          ),
         ];
       });
 

--- a/templates/notes_app_shelf/frontend/pubspec.lock
+++ b/templates/notes_app_shelf/frontend/pubspec.lock
@@ -148,26 +148,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -188,18 +188,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
@@ -265,10 +265,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -289,10 +289,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: f652077d0bdf60abe4c1f6377448e8655008eef28f128bc023f7b5e8dfeb48fc
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.4"
   web:
     dependency: transitive
     description:
@@ -303,4 +303,4 @@ packages:
     version: "0.5.1"
 sdks:
   dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.3.0"
+  flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
## Description

This enables CIs to use `globe <command> --project=id --org=id` instead of having to use `globe link` first.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
