### PR TITLE
chore: Make --token applicable to all other commands

### DIFF
--- a/packages/globe_cli/lib/src/command.dart
+++ b/packages/globe_cli/lib/src/command.dart
@@ -46,19 +46,12 @@ abstract class BaseGlobeCommand extends Command<int> {
   }
 
   ScopeValidator declareScopeArguments() {
-    argParser
-      ..addOption(
-        'org',
-        abbr: 'o',
-        help: 'The organization ID used by this command. '
-            'Defaults to what was previously linked using `globe link`.',
-      )
-      ..addOption(
-        'project',
-        abbr: 'p',
-        help: 'The Project ID used by this command. '
-            'Defaults to what was previously linked using `globe link`.',
-      );
+    argParser.addOption(
+      'org',
+      abbr: 'o',
+      help: 'The organization ID used by this command. '
+          'Defaults to what was previously linked using `globe link`.',
+    );
 
     return () => scope.validate(argResults);
   }

--- a/packages/globe_cli/lib/src/command.dart
+++ b/packages/globe_cli/lib/src/command.dart
@@ -46,13 +46,6 @@ abstract class BaseGlobeCommand extends Command<int> {
   }
 
   ScopeValidator declareScopeArguments() {
-    argParser.addOption(
-      'org',
-      abbr: 'o',
-      help: 'The organization ID used by this command. '
-          'Defaults to what was previously linked using `globe link`.',
-    );
-
     return () => scope.validate(argResults);
   }
 }

--- a/packages/globe_cli/lib/src/commands/deploy_command.dart
+++ b/packages/globe_cli/lib/src/commands/deploy_command.dart
@@ -26,11 +26,6 @@ class DeployCommand extends BaseGlobeCommand {
       ..addFlag(
         'logs',
         help: 'Shows build logs for the deployment.',
-      )
-      ..addOption(
-        'token',
-        abbr: 't',
-        help: 'Set the API token for deployment. Also needs --project',
       );
 
     _validator = declareScopeArguments();
@@ -50,26 +45,6 @@ class DeployCommand extends BaseGlobeCommand {
 
   @override
   Future<int> run() async {
-    if (argResults?['token'] != null && argResults?['project'] != null) {
-      final token = argResults!['token'] as String;
-      final project = argResults!['project'] as String;
-      api.auth.loginWithApiToken(jwt: token);
-
-      final organizations = await api.getOrganizations();
-      logger.detail('Found ${organizations.length} organizations');
-
-      if (organizations.isEmpty) {
-        logger.err(
-          'API Token provided is invalid or is not associated with any organizations.',
-        );
-        return ExitCode.usage.code;
-      }
-
-      scope.setScope(orgId: organizations.first.id, projectId: project);
-    } else {
-      requireAuth();
-    }
-
     // If there is no scope, ask the user to link the project.
     if (!scope.hasScope()) {
       await linkProject(logger: logger, api: api);

--- a/packages/globe_cli/lib/src/package_info.dart
+++ b/packages/globe_cli/lib/src/package_info.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE. DO NOT EDIT BY HAND.
 
-const name = 'globe_cli';
+const name = 'globe';
 const version = '0.0.12';
 const description = 'Globe CLI';
 const executable = 'globe';

--- a/packages/globe_cli/lib/src/utils/api.dart
+++ b/packages/globe_cli/lib/src/utils/api.dart
@@ -695,7 +695,6 @@ class Token {
         'organizationUuid': final String organizationUuid,
         'expiresAt': final String expiresAt,
         'projects': final List<dynamic> projects,
-        'value': final String? value,
       } =>
         Token._(
           uuid: uuid,
@@ -705,7 +704,7 @@ class Token {
           cliTokenClaimProject: projects
               .map((e) => (e as Map)['projectUuid'].toString())
               .toList(),
-          value: value,
+          value: json['value']?.toString(),
         ),
       _ => throw const FormatException('Token'),
     };

--- a/packages/globe_cli/lib/src/utils/prompts.dart
+++ b/packages/globe_cli/lib/src/utils/prompts.dart
@@ -82,16 +82,21 @@ Future<ScopeMetadata> linkProject({
 Future<Organization> selectOrganization({
   required Logger logger,
   required GlobeApi api,
+  void Function()? onNoOrganizationsError,
 }) async {
   logger.detail('Fetching user organizations');
   final organizations = await api.getOrganizations();
   logger.detail('Found ${organizations.length} organizations');
 
   if (organizations.isEmpty) {
-    logger.detail(
-      'No organizations found, this is likely a new account which is still being setup. Please try again in a few seconds.',
-    );
-    logger.err('Your account is still being setup, please try again.');
+    if (onNoOrganizationsError == null) {
+      logger.detail(
+        'No organizations found, this is likely a new account which is still being setup. Please try again in a few seconds.',
+      );
+      logger.err('Your account is still being setup, please try again.');
+    } else {
+      onNoOrganizationsError.call();
+    }
     exitOverride(1);
   }
 

--- a/packages/globe_cli/lib/src/utils/scope.dart
+++ b/packages/globe_cli/lib/src/utils/scope.dart
@@ -55,8 +55,8 @@ class GlobeScope {
     return current != null;
   }
 
-  Future<Organization> _findOrg(ArgResults? argResults) async {
-    final orgId = argResults?['org'] ?? current?.orgId;
+  Future<Organization> _findOrg() async {
+    final orgId = current?.orgId;
     if (orgId is! String) return selectOrganization(logger: logger, api: api);
 
     final organizations = await api.getOrganizations();
@@ -87,7 +87,7 @@ class GlobeScope {
 
   Future<ScopeValidation> validate(ArgResults? argResults) async {
     try {
-      final organization = await _findOrg(argResults);
+      final organization = await _findOrg();
       final project = await _findProject(organization);
 
       logger.detail('Validated scope: ${organization.slug}/${project.slug}');

--- a/packages/globe_cli/lib/src/utils/scope.dart
+++ b/packages/globe_cli/lib/src/utils/scope.dart
@@ -57,7 +57,6 @@ class GlobeScope {
 
   Future<Organization> _findOrg(ArgResults? argResults) async {
     final orgId = argResults?['org'] ?? current?.orgId;
-
     if (orgId is! String) return selectOrganization(logger: logger, api: api);
 
     final organizations = await api.getOrganizations();
@@ -70,12 +69,8 @@ class GlobeScope {
     );
   }
 
-  Future<Project> _findProject(
-    ArgResults? argResults,
-    Organization org,
-  ) async {
-    final projectId = argResults?['project'] ?? current?.projectId;
-
+  Future<Project> _findProject(Organization org) async {
+    final projectId = current?.projectId;
     if (projectId is! String) {
       return selectProject(org, logger: logger, api: api);
     }
@@ -93,7 +88,7 @@ class GlobeScope {
   Future<ScopeValidation> validate(ArgResults? argResults) async {
     try {
       final organization = await _findOrg(argResults);
-      final project = await _findProject(argResults, organization);
+      final project = await _findProject(organization);
 
       logger.detail('Validated scope: ${organization.slug}/${project.slug}');
 


### PR DESCRIPTION
Allow `--token` to be parsed for all other commands, not just `deploy`.