### PR TITLE
feat: Multi project linking via CLI

### DIFF
--- a/packages/globe_cli/lib/src/command_runner.dart
+++ b/packages/globe_cli/lib/src/command_runner.dart
@@ -16,7 +16,6 @@ import 'utils/api.dart';
 import 'utils/auth.dart';
 import 'utils/http_server.dart';
 import 'utils/metadata.dart';
-import 'utils/prompts.dart';
 import 'utils/scope.dart';
 
 class GlobeCliCommandRunner extends CompletionCommandRunner<int> {

--- a/packages/globe_cli/lib/src/command_runner.dart
+++ b/packages/globe_cli/lib/src/command_runner.dart
@@ -135,12 +135,21 @@ class GlobeCliCommandRunner extends CompletionCommandRunner<int> {
       auth.loadSession();
       scope.loadScope(projectIdOrSlug: maybeProjectIdOrSlug);
 
+      Organization? org;
+
       if (maybeToken != null) {
         api.auth.loginWithApiToken(jwt: maybeToken);
+        org = await selectOrganization(
+          logger: _logger,
+          api: api,
+          onNoOrganizationsError: () => _logger.err(
+            'API Token provided is invalid or is not associated with any organizations.',
+          ),
+        );
       }
 
       if (maybeProjectIdOrSlug != null && !scope.hasScope()) {
-        final org = await selectOrganization(logger: _logger, api: api);
+        org ??= await selectOrganization(logger: _logger, api: api);
         final projects = await api.getProjects(org: org.id);
 
         final selectedProject = projects.firstWhere(

--- a/packages/globe_cli/lib/src/command_runner.dart
+++ b/packages/globe_cli/lib/src/command_runner.dart
@@ -128,52 +128,19 @@ class GlobeCliCommandRunner extends CompletionCommandRunner<int> {
       GetIt.instance.registerSingleton<GlobeMetadata>(metadata);
       GetIt.instance.registerSingleton<GlobeScope>(scope);
 
-      final maybeToken = topLevelResults['token'];
-      final maybeProjectId = topLevelResults['project'];
-      final maybeOrgId = topLevelResults['org'];
-
-      Organization? org;
-      Project? project;
-
-      if (maybeToken != null) {
-        api.auth.loginWithApiToken(jwt: maybeToken as String);
-        org = await selectOrganization(
-          logger: _logger,
-          api: api,
-          onNoOrganizationsError: () => _logger.err(
-            'API Token provided is invalid or is not associated with any organizations.',
-          ),
-        );
-      }
+      final maybeProjectId = topLevelResults['project'] as String?;
+      final maybeToken = topLevelResults['token'] as String?;
 
       // Load the current project scope.
-      scope.loadScope();
       auth.loadSession();
+      scope.loadScope(projectId: maybeProjectId);
 
-      final currentSession = auth.currentSession;
-
-      if (maybeOrgId != null) {
-        if (currentSession == null) throw Exception('Auth required.');
-        final orgs = await api.getOrganizations();
-        org = orgs.firstWhere(
-          (org) => org.id == maybeOrgId,
-          orElse: () => throw Exception('Project #$maybeProjectId not found.'),
-        );
+      if (maybeProjectId != null && !scope.hasScope()) {
+        throw Exception('Project #$maybeProjectId not found.');
       }
 
-      if (maybeProjectId != null) {
-        if (currentSession == null) throw Exception('Auth required.');
-        if (org == null) throw Exception('Organization not found.');
-
-        final projects = await api.getProjects(org: org.id);
-        project = projects.firstWhere(
-          (project) => project.id == maybeProjectId,
-          orElse: () => throw Exception('Project #$maybeProjectId not found.'),
-        );
-      }
-
-      if (org != null && project != null) {
-        scope.setScope(orgId: org.id, projectId: project.id);
+      if (maybeToken != null) {
+        api.auth.loginWithApiToken(jwt: maybeToken);
       }
 
       return await runCommand(topLevelResults) ?? ExitCode.success.code;

--- a/packages/globe_cli/lib/src/commands/build_logs_command.dart
+++ b/packages/globe_cli/lib/src/commands/build_logs_command.dart
@@ -25,6 +25,8 @@ class BuildLogsCommand extends BaseGlobeCommand {
   Future<int> run() async {
     requireAuth();
 
+    await scope.selectScopeOrLinkNewScope();
+
     final validated = await _validator();
     final deploymentId = argResults!['deployment'] as String?;
 

--- a/packages/globe_cli/lib/src/commands/build_logs_command.dart
+++ b/packages/globe_cli/lib/src/commands/build_logs_command.dart
@@ -25,7 +25,7 @@ class BuildLogsCommand extends BaseGlobeCommand {
   Future<int> run() async {
     requireAuth();
 
-    await scope.selectScopeOrLinkNewScope();
+    await scope.selectOrLinkNewScope();
 
     final validated = await _validator();
     final deploymentId = argResults!['deployment'] as String?;

--- a/packages/globe_cli/lib/src/commands/deploy_command.dart
+++ b/packages/globe_cli/lib/src/commands/deploy_command.dart
@@ -7,7 +7,6 @@ import '../command.dart';
 import '../utils/api.dart';
 import '../utils/archiver.dart';
 import '../utils/logs.dart';
-import '../utils/prompts.dart';
 
 /// `globe deploy`
 ///

--- a/packages/globe_cli/lib/src/commands/deploy_command.dart
+++ b/packages/globe_cli/lib/src/commands/deploy_command.dart
@@ -45,10 +45,7 @@ class DeployCommand extends BaseGlobeCommand {
 
   @override
   Future<int> run() async {
-    // If there is no scope, ask the user to link the project.
-    if (!scope.hasScope()) {
-      await linkProject(logger: logger, api: api);
-    }
+    await scope.selectScopeOrLinkNewScope();
 
     final validated = await _validator();
     if (validated.project.paused) {

--- a/packages/globe_cli/lib/src/commands/deploy_command.dart
+++ b/packages/globe_cli/lib/src/commands/deploy_command.dart
@@ -44,7 +44,7 @@ class DeployCommand extends BaseGlobeCommand {
 
   @override
   Future<int> run() async {
-    await scope.selectScopeOrLinkNewScope();
+    await scope.selectOrLinkNewScope();
 
     final validated = await _validator();
     if (validated.project.paused) {

--- a/packages/globe_cli/lib/src/commands/link_command.dart
+++ b/packages/globe_cli/lib/src/commands/link_command.dart
@@ -9,7 +9,11 @@ import '../utils/prompts.dart';
 /// Links the local project to a Globe project.
 class LinkCommand extends BaseGlobeCommand {
   LinkCommand() {
-    argParser.addFlag('show-all', help: 'Show all linked projects');
+    argParser.addFlag(
+      'show-all',
+      help: 'Show all linked projects',
+      negatable: false,
+    );
   }
 
   @override

--- a/packages/globe_cli/lib/src/commands/link_command.dart
+++ b/packages/globe_cli/lib/src/commands/link_command.dart
@@ -1,3 +1,4 @@
+import 'package:cli_table/cli_table.dart';
 import 'package:mason_logger/mason_logger.dart';
 
 import '../command.dart';
@@ -7,6 +8,10 @@ import '../utils/prompts.dart';
 ///
 /// Links the local project to a Globe project.
 class LinkCommand extends BaseGlobeCommand {
+  LinkCommand() {
+    argParser.addFlag('show-all', help: 'Show all linked projects');
+  }
+
   @override
   String get description => 'Link this local project to a Globe project.';
 
@@ -15,6 +20,31 @@ class LinkCommand extends BaseGlobeCommand {
 
   @override
   Future<int> run() async {
+    final showLinked = argResults!['show-all'] as bool;
+    if (showLinked) {
+      final linkedProjects = scope.workspace;
+      if (linkedProjects.isEmpty) return ExitCode.success.code;
+
+      final table = Table(
+        header: [
+          cyan.wrap('Project'),
+          cyan.wrap('Project ID'),
+          cyan.wrap('Organization ID'),
+        ],
+        columnWidths: [30, 30, 30],
+      );
+      for (final project in linkedProjects) {
+        table.add([
+          project.projectSlug,
+          project.projectId,
+          project.orgId,
+        ]);
+      }
+
+      logger.info(table.toString());
+      return ExitCode.success.code;
+    }
+
     requireAuth();
 
     await linkProject(logger: logger, api: api);

--- a/packages/globe_cli/lib/src/commands/project/project_pause_command.dart
+++ b/packages/globe_cli/lib/src/commands/project/project_pause_command.dart
@@ -22,6 +22,8 @@ class ProjectPauseCommand extends BaseGlobeCommand {
   FutureOr<int> run() async {
     requireAuth();
 
+    await scope.selectScopeOrLinkNewScope();
+
     final validated = await _validator();
     final projectSlug = validated.project.slug;
     final pauseProjectProgress =

--- a/packages/globe_cli/lib/src/commands/project/project_pause_command.dart
+++ b/packages/globe_cli/lib/src/commands/project/project_pause_command.dart
@@ -22,7 +22,7 @@ class ProjectPauseCommand extends BaseGlobeCommand {
   FutureOr<int> run() async {
     requireAuth();
 
-    await scope.selectScopeOrLinkNewScope();
+    await scope.selectOrLinkNewScope();
 
     final validated = await _validator();
     final projectSlug = validated.project.slug;

--- a/packages/globe_cli/lib/src/commands/project/project_resume_command.dart
+++ b/packages/globe_cli/lib/src/commands/project/project_resume_command.dart
@@ -22,6 +22,8 @@ class ProjectResumeCommand extends BaseGlobeCommand {
   FutureOr<int> run() async {
     requireAuth();
 
+    await scope.selectScopeOrLinkNewScope();
+
     final validated = await _validator();
     final projectSlug = validated.project.slug;
     final pauseProjectProgress =

--- a/packages/globe_cli/lib/src/commands/project/project_resume_command.dart
+++ b/packages/globe_cli/lib/src/commands/project/project_resume_command.dart
@@ -22,7 +22,7 @@ class ProjectResumeCommand extends BaseGlobeCommand {
   FutureOr<int> run() async {
     requireAuth();
 
-    await scope.selectScopeOrLinkNewScope();
+    await scope.selectOrLinkNewScope();
 
     final validated = await _validator();
     final projectSlug = validated.project.slug;

--- a/packages/globe_cli/lib/src/commands/token/token_delete_command.dart
+++ b/packages/globe_cli/lib/src/commands/token/token_delete_command.dart
@@ -4,7 +4,6 @@ import 'package:mason_logger/mason_logger.dart';
 
 import '../../command.dart';
 import '../../utils/api.dart';
-import '../../utils/prompts.dart';
 
 class TokenDeleteCommand extends BaseGlobeCommand {
   TokenDeleteCommand() {
@@ -23,8 +22,8 @@ class TokenDeleteCommand extends BaseGlobeCommand {
   @override
   FutureOr<int> run() async {
     requireAuth();
+    await scope.selectOrLinkNewScope();
 
-    final organization = await selectOrganization(logger: logger, api: api);
     final tokenId = (argResults?['tokenId'] as String?) ??
         logger.prompt('❓ Provide id for token:');
 
@@ -32,10 +31,7 @@ class TokenDeleteCommand extends BaseGlobeCommand {
         logger.progress('Deleting Token: ${cyan.wrap(tokenId)}');
 
     try {
-      await api.deleteToken(
-        orgId: organization.id,
-        tokenId: tokenId,
-      );
+      await api.deleteToken(orgId: scope.current!.orgId, tokenId: tokenId);
       deleteTokenProgress.complete('Token deleted');
     } on ApiException catch (e) {
       deleteTokenProgress.fail('✗ Failed to delete token: ${e.message}');

--- a/packages/globe_cli/lib/src/commands/unlink_command.dart
+++ b/packages/globe_cli/lib/src/commands/unlink_command.dart
@@ -18,21 +18,14 @@ class UnlinkCommand extends BaseGlobeCommand {
 
     if (scope.hasScope()) {
       scope.unlink();
-      logger.success(
-        'Project unlinked successfully. To link this project again, run ${cyan.wrap('globe link')}.',
-      );
-      return ExitCode.success.code;
-    }
-
-    if (scope.workspace.isNotEmpty) {
+    } else if (scope.workspace.isNotEmpty) {
       final selected = await scope.selectScopeOrLinkNewScope(canLinkNew: false);
       scope.removeScope(selected);
-      logger.success(
-        'Project unlinked successfully. To link this project again, run ${cyan.wrap('globe link')}.',
-      );
-      return ExitCode.success.code;
     }
 
-    return ExitCode.software.code;
+    logger.success(
+      'Project unlinked successfully. To link this project again, run ${cyan.wrap('globe link')}.',
+    );
+    return ExitCode.success.code;
   }
 }

--- a/packages/globe_cli/lib/src/commands/unlink_command.dart
+++ b/packages/globe_cli/lib/src/commands/unlink_command.dart
@@ -17,7 +17,7 @@ class UnlinkCommand extends BaseGlobeCommand {
     requireAuth();
 
     if (scope.hasScope()) {
-      scope.clear();
+      scope.unlink();
       logger.success(
         'Project unlinked successfully. To link this project again, run ${cyan.wrap('globe link')}.',
       );

--- a/packages/globe_cli/lib/src/commands/unlink_command.dart
+++ b/packages/globe_cli/lib/src/commands/unlink_command.dart
@@ -15,10 +15,24 @@ class UnlinkCommand extends BaseGlobeCommand {
   @override
   Future<int> run() async {
     requireAuth();
-    scope.clear();
-    logger.success(
-      'Project unlinked successfully. To link this project again, run ${cyan.wrap('globe link')}.',
-    );
-    return ExitCode.success.code;
+
+    if (scope.hasScope()) {
+      scope.clear();
+      logger.success(
+        'Project unlinked successfully. To link this project again, run ${cyan.wrap('globe link')}.',
+      );
+      return ExitCode.success.code;
+    }
+
+    if (scope.workspace.isNotEmpty) {
+      final selected = await scope.selectScopeOrLinkNewScope(canLinkNew: false);
+      scope.removeScope(selected);
+      logger.success(
+        'Project unlinked successfully. To link this project again, run ${cyan.wrap('globe link')}.',
+      );
+      return ExitCode.success.code;
+    }
+
+    return ExitCode.software.code;
   }
 }

--- a/packages/globe_cli/lib/src/commands/unlink_command.dart
+++ b/packages/globe_cli/lib/src/commands/unlink_command.dart
@@ -20,7 +20,7 @@ class UnlinkCommand extends BaseGlobeCommand {
       scope.unlink();
     } else if (scope.workspace.isNotEmpty) {
       final selected = await scope.selectOrLinkNewScope(canLinkNew: false);
-      scope.removeScope(selected);
+      scope.unlinkScope(selected);
     }
 
     logger.success(

--- a/packages/globe_cli/lib/src/commands/unlink_command.dart
+++ b/packages/globe_cli/lib/src/commands/unlink_command.dart
@@ -19,7 +19,7 @@ class UnlinkCommand extends BaseGlobeCommand {
     if (scope.hasScope()) {
       scope.unlink();
     } else if (scope.workspace.isNotEmpty) {
-      final selected = await scope.selectScopeOrLinkNewScope(canLinkNew: false);
+      final selected = await scope.selectOrLinkNewScope(canLinkNew: false);
       scope.removeScope(selected);
     }
 

--- a/packages/globe_cli/lib/src/utils/api.dart
+++ b/packages/globe_cli/lib/src/utils/api.dart
@@ -16,6 +16,9 @@ class ApiException implements Exception {
 
   final int statusCode;
   final String message;
+
+  @override
+  String toString() => 'ApiException: [$statusCode] $message';
 }
 
 class GlobeApi {

--- a/packages/globe_cli/lib/src/utils/api.dart
+++ b/packages/globe_cli/lib/src/utils/api.dart
@@ -108,29 +108,43 @@ class GlobeApi {
   }
 
   /// Gets all of the organizations that the current user is a member of.
+  List<Organization>? _orgsCache;
   Future<List<Organization>> getOrganizations() async {
+    if (_orgsCache != null && _orgsCache!.isNotEmpty) {
+      logger.detail('Cached API Request: GET /user/orgs');
+      return _orgsCache!;
+    }
+
     requireAuth();
     logger.detail('API Request: GET /user/orgs');
     final response = _handleResponse(
       await http.get(_buildUri('/user/orgs'), headers: headers),
     )! as List<Object?>;
 
-    return response
+    return _orgsCache = response
         .cast<Map<String, Object?>>()
         .map(Organization.fromJson)
         .toList();
   }
 
   /// Gets all of the projects that the current user is a member of.
+  List<Project>? _projectsCache;
   Future<List<Project>> getProjects({
     required String org,
   }) async {
+    if (_projectsCache != null && _projectsCache!.isNotEmpty) {
+      logger.detail('Cached API Request: GET /orgs/$org/projects');
+      return _projectsCache!;
+    }
+
     requireAuth();
     logger.detail('API Request: GET /orgs/$org/projects');
     final response = _handleResponse(
       await http.get(_buildUri('/orgs/$org/projects'), headers: headers),
     )! as List<Object?>;
-    return response.cast<Map<String, Object?>>().map(Project.fromJson).toList();
+
+    return _projectsCache =
+        response.cast<Map<String, Object?>>().map(Project.fromJson).toList();
   }
 
   /// Creates a new project and returns it.

--- a/packages/globe_cli/lib/src/utils/prompts.dart
+++ b/packages/globe_cli/lib/src/utils/prompts.dart
@@ -20,17 +20,6 @@ Future<ScopeMetadata> linkProject({
   required Logger logger,
   required GlobeApi api,
 }) async {
-  // TODO inject as function parameter
-  final scope = GetIt.I<GlobeScope>();
-
-  if (scope.hasScope()) {
-    if (!logger.confirm(
-      '❓ Project already linked, would you like to link to a different project?',
-    )) {
-      exitOverride(0);
-    }
-  }
-
   try {
     final organization = await selectOrganization(
       logger: logger,
@@ -43,9 +32,12 @@ Future<ScopeMetadata> linkProject({
       api: api,
     );
 
-    final result = scope.setScope(
-      orgId: organization.id,
-      projectId: project.id,
+    final result = GetIt.I<GlobeScope>().setScope(
+      ScopeMetadata(
+        orgId: organization.id,
+        projectId: project.id,
+        projectSlug: project.slug,
+      ),
     );
 
     final projectUrl = Uri.parse(api.metadata.endpoint)
@@ -116,6 +108,7 @@ Future<Project> selectProject(
   Organization organization, {
   required Logger logger,
   required GlobeApi api,
+  String message = '❓ Please select a project you want to link:',
 }) async {
   logger.detail('Fetching organization projects');
   final projects = await api.getProjects(org: organization.id);
@@ -293,7 +286,7 @@ Future<Project> selectProject(
 
   // Select a project or create a new one.
   final selectedProject = logger.chooseOne(
-    '❓ Please select a project you want to deploy to:',
+    message,
     choices: [
       if (api.auth.currentSession?.authenticationMethod !=
           AuthenticationMethod.apiToken)

--- a/packages/globe_cli/lib/src/utils/scope.dart
+++ b/packages/globe_cli/lib/src/utils/scope.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:collection/collection.dart';
 import 'package:mason_logger/mason_logger.dart';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 
 import '../exit.dart';
@@ -31,10 +30,6 @@ class GlobeScope {
 
   late final List<ScopeMetadata> workspace;
 
-  /// The current project metadata, or `null` if the project has not been setup.
-  ///
-  /// Use [validate] instead if you're looking to read the current project metadata.
-  @protected
   ScopeMetadata? get current => _current;
   ScopeMetadata? _current;
 

--- a/packages/globe_cli/lib/src/utils/scope.dart
+++ b/packages/globe_cli/lib/src/utils/scope.dart
@@ -89,7 +89,7 @@ class GlobeScope {
     return current != null;
   }
 
-  Future<ScopeMetadata> selectScopeOrLinkNewScope({
+  Future<ScopeMetadata> selectOrLinkNewScope({
     bool canLinkNew = true,
   }) async {
     if (hasScope()) return current!;

--- a/packages/globe_cli/lib/src/utils/scope.dart
+++ b/packages/globe_cli/lib/src/utils/scope.dart
@@ -76,7 +76,7 @@ class GlobeScope {
     return _current = scope;
   }
 
-  void removeScope(ScopeMetadata scope) {
+  void unlinkScope(ScopeMetadata scope) {
     if (workspace.isEmpty) return;
     workspace.removeWhere(
       (e) => e.orgId == scope.orgId && e.projectId == scope.projectId,
@@ -189,7 +189,7 @@ class GlobeScope {
   /// Clears the current project metadata.
   void unlink() {
     if (_current == null) return;
-    removeScope(_current!);
+    unlinkScope(_current!);
     _current = null;
   }
 

--- a/packages/globe_cli/lib/src/utils/scope.dart
+++ b/packages/globe_cli/lib/src/utils/scope.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:collection/collection.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
@@ -28,6 +29,8 @@ class GlobeScope {
     );
   }
 
+  late final List<ScopeMetadata> workspace;
+
   /// The current project metadata, or `null` if the project has not been setup.
   ///
   /// Use [validate] instead if you're looking to read the current project metadata.
@@ -42,17 +45,79 @@ class GlobeScope {
   final GlobeApi api;
   final GlobeMetadata metadata;
 
-  /// Sets the current project scope.
-  ScopeMetadata setScope({required String orgId, required String projectId}) {
-    final result = _current = ScopeMetadata(orgId: orgId, projectId: projectId);
-    _projectFile.createSync(recursive: true);
-    _projectFile.writeAsStringSync(json.encode(_current!.toJson()));
+  ScopeMetadata? _findScope(String projectId, {String? orgId}) {
+    return workspace.firstWhereOrNull(
+      (e) {
+        if (orgId == null) return e.projectId == projectId;
+        return e.projectId == projectId && e.orgId == orgId;
+      },
+    );
+  }
 
-    return result;
+  void _writeWorkspaceToFile() {
+    _projectFile
+      ..createSync(recursive: true)
+      ..writeAsStringSync(const JsonEncoder.withIndent(' ').convert(workspace));
+  }
+
+  /// Sets the current project scope.
+  ScopeMetadata setScope(ScopeMetadata scope) {
+    final existing = _findScope(scope.projectId, orgId: scope.orgId);
+    if (existing != null) return _current = existing;
+
+    workspace.add(scope);
+    _writeWorkspaceToFile();
+
+    return _current = scope;
+  }
+
+  void removeScope(ScopeMetadata scope) {
+    if (workspace.isEmpty) return;
+    workspace.removeWhere(
+      (e) => e.orgId == scope.orgId && e.projectId == scope.projectId,
+    );
+
+    _writeWorkspaceToFile();
   }
 
   bool hasScope() {
     return current != null;
+  }
+
+  Future<ScopeMetadata> selectScopeOrLinkNewScope({
+    bool canLinkNew = true,
+  }) async {
+    if (hasScope()) return current!;
+
+    final selectOrg = await selectOrganization(logger: logger, api: api);
+    const linkNewProjectSymbol = '__LINK_NEW_PROJECT';
+
+    final scopes = workspace.where((p) => p.orgId == selectOrg.id);
+    var selectedProject = linkNewProjectSymbol;
+
+    if (scopes.length > 1) {
+      selectedProject = logger.chooseOne(
+        '🔺 Select project:',
+        choices: [
+          ...scopes.map((o) => o.projectId),
+          if (canLinkNew) linkNewProjectSymbol,
+        ],
+        display: (choice) {
+          if (choice == linkNewProjectSymbol) {
+            return lightYellow.wrap('link new project +')!;
+          }
+          return scopes.firstWhere((o) => o.projectId == choice).projectSlug;
+        },
+      );
+    }
+
+    if (selectedProject != linkNewProjectSymbol) {
+      return setScope(
+        scopes.firstWhere((scope) => scope.projectId == selectedProject),
+      );
+    }
+
+    return linkProject(logger: logger, api: api);
   }
 
   Future<Organization> _findOrg() async {
@@ -108,22 +173,38 @@ class GlobeScope {
   /// Clears the current project metadata.
   void clear() {
     _current = null;
+    workspace.clear();
     if (_projectFile.existsSync()) {
       _projectFile.deleteSync(recursive: true);
     }
   }
 
   /// Sets the current scope metadata.
-  void loadScope() {
-    if (_projectFile.existsSync()) {
-      try {
-        final contents = _projectFile.readAsStringSync();
-        _current = ScopeMetadata.fromJson(
-          json.decode(contents) as Map<String, dynamic>,
-        );
-      } catch (_) {
-        // TODO(rrousselGit) why are we catching and ignoring errors?
-      }
+  void loadScope({String? projectId}) {
+    if (!_projectFile.existsSync()) {
+      workspace = [];
+      return;
+    }
+
+    final contents = _projectFile.readAsStringSync();
+    if (contents.trim().isEmpty) {
+      workspace = [];
+      return;
+    }
+
+    final jsonContent = json.decode(contents);
+    workspace = switch (jsonContent) {
+      Map<String, dynamic>() => [ScopeMetadata.fromJson(jsonContent)],
+      List<dynamic>() => jsonContent
+          .map((e) => ScopeMetadata.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      _ => throw StateError('Invalid workspace schema'),
+    };
+
+    if (projectId != null) {
+      _current = _findScope(projectId);
+    } else if (workspace.length == 1) {
+      _current = workspace[0];
     }
   }
 }
@@ -144,6 +225,7 @@ class ScopeMetadata {
   const ScopeMetadata({
     required this.orgId,
     required this.projectId,
+    required this.projectSlug,
   });
 
   /// Creates a new [ScopeMetadata] instance from the given [json].
@@ -151,6 +233,7 @@ class ScopeMetadata {
     return ScopeMetadata(
       orgId: json['orgId'] as String,
       projectId: json['projectId'] as String,
+      projectSlug: json['projectSlug'] as String,
     );
   }
 
@@ -160,6 +243,13 @@ class ScopeMetadata {
   /// The project ID, which belongs to the org.
   final String projectId;
 
+  /// The project Slug,
+  final String projectSlug;
+
   /// Converts this [ScopeMetadata] instance to a JSON map.
-  Map<String, dynamic> toJson() => {'orgId': orgId, 'projectId': projectId};
+  Map<String, dynamic> toJson() => {
+        'orgId': orgId,
+        'projectId': projectId,
+        'projectSlug': projectSlug,
+      };
 }

--- a/packages/globe_cli/lib/src/utils/scope.dart
+++ b/packages/globe_cli/lib/src/utils/scope.dart
@@ -114,6 +114,8 @@ class GlobeScope {
           return scopes.firstWhere((o) => o.projectId == choice).projectSlug;
         },
       );
+    } else if (scopes.length == 1) {
+      return setScope(scopes.first);
     }
 
     if (selectedProject != linkNewProjectSymbol) {

--- a/packages/globe_cli/pubspec.lock
+++ b/packages/globe_cli/pubspec.lock
@@ -151,7 +151,7 @@ packages:
     source: hosted
     version: "4.10.0"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"

--- a/packages/globe_cli/pubspec.lock
+++ b/packages/globe_cli/pubspec.lock
@@ -22,6 +22,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.8.0"
+  ansi_regex:
+    dependency: transitive
+    description:
+      name: ansi_regex
+      sha256: ca4f2b24a85e797a1512e1d3fe34d5f8429648f78e2268b6a8b5628c8430e643
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2"
+  ansi_strip:
+    dependency: transitive
+    description:
+      name: ansi_strip
+      sha256: "9bb54e10962ac1de86b9b64a278a5b8965a28a2f741975eac7fe9fb0ebe1aaac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1+1"
   archive:
     dependency: "direct main"
     description:
@@ -118,6 +134,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.9.2"
+  chalkdart:
+    dependency: transitive
+    description:
+      name: chalkdart
+      sha256: "0b7ec5c6a6bafd1445500632c00c573722bd7736e491675d4ac3fe560bbd9cfe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      sha256: "81269c8d3f45541082bfbb117bbc962cfc68b5197eb4c705a00db4ddf394e1c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -134,6 +166,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.0"
+  cli_table:
+    dependency: "direct main"
+    description:
+      name: cli_table
+      sha256: "61b61c6dbfa248d8ec9c65b1d97d1ec1952482765563533087ec550405def016"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.2"
   cli_util:
     dependency: "direct main"
     description:
@@ -190,6 +230,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.7"
+  east_asian_width:
+    dependency: transitive
+    description:
+      name: east_asian_width
+      sha256: a13c5487dab7ddbad48875789819f0ea38a61cbaaa3024ebe7b199521e6f5788
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  emoji_regex:
+    dependency: transitive
+    description:
+      name: emoji_regex
+      sha256: "3a25dd4d16f98b6f76dc37cc9ae49b8511891ac4b87beac9443a1e9f4634b6c7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.5"
   equatable:
     dependency: transitive
     description:
@@ -549,6 +605,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  string_width:
+    dependency: transitive
+    description:
+      name: string_width
+      sha256: "0ea481fbb6d5e2d70937fea303d8cc9296048da107dffeecf2acb675c8b47e7f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.5"
   term_glyph:
     dependency: transitive
     description:
@@ -613,6 +677,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  wcwidth:
+    dependency: transitive
+    description:
+      name: wcwidth
+      sha256: "4e68ce25701e56647cb305ab6d8c75fce5e5196227bcb6ba6886513ac36474c2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.4"
   web:
     dependency: transitive
     description:

--- a/packages/globe_cli/pubspec.yaml
+++ b/packages/globe_cli/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   pubspec_parse: ^1.2.3
   pool: ^1.5.1
   collection: ^1.19.1
+  cli_table: ^1.0.2
 
 dev_dependencies:
   build_runner: ^2.4.4

--- a/packages/globe_cli/pubspec.yaml
+++ b/packages/globe_cli/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   pub_updater: ^0.3.0
   pubspec_parse: ^1.2.3
   pool: ^1.5.1
+  collection: ^1.19.1
 
 dev_dependencies:
   build_runner: ^2.4.4


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Closes: https://github.com/orgs/invertase/projects/23/views/1?pane=issue&itemId=54493236&issue=invertase%7Cdart_globe%7C97

This PR introduces the ability to link multiple projects within the same directory (e.g., mono-repos). By updating the `project.json` schema to support a list of `ScopeMetadata`, users can now link and manage multiple projects seamlessly.



```json
[
  {
    "orgId": "eecbc0fb-ee17-4d87-9b74-0ce33e1b7cf1",
    "projectId": "bd239097-1b68-43e6-a887-466e4f786da3",
    "projectSlug": "blog-backend-369d"
  },
  {
    "orgId": "eecbc0fb-ee17-4d87-9b74-0ce33e1b7cf1",
    "projectId": "2e8e0149-db61-4883-b734-4d6832824ca5",
    "projectSlug": "blog-frontend"
  }
]
```

<!--- Describe your changes in detail and provide screenshots of the output of the change if possible, e.g. screenshot of the CLI output. -->

## Key Changes

- #### Multi-project linking

`globe link` command now supports linking multiple projects.
```sh
 ~/Projects/OpenSource/dart-blog | on main >1 !3 ?1  globe link                                                                                                                 
❓ Please select a project you want to link:
❯ ◉  Create a new project
  ◯  blog-frontend
  ◯  blog-backend-369d
  ◯  stay-hydrated
  ◯  newsapi
```

Similarly, `globe unlink` also displays linked projects so you can select to unlink.
```sh
 ~/Projects/OpenSource/dart-blog | on main >1 !3 ?1  globe unlink                                                                                                                    
🔺 Select project:
❯ ◉  blog-backend-369d
  ◯  blog-frontend
```

To show all linked project within workspace, you can run `globe link --show-all`
```sh
 ~/Projects/OpenSource/dart-blog | on main >1 !3 ?1  glober link --show-all                                                                                                                   ok 
┌──────────────────────────────┬──────────────────────────────┬──────────────────────────────┐
│ Project                      │ Project ID                   │ Organization ID              │
├──────────────────────────────┼──────────────────────────────┼──────────────────────────────┤
│ blog-backend-369d            │ bd239097-1b68-43e6-a887-466… │ eecbc0fb-ee17-4d87-9b74-0ce… │
├──────────────────────────────┼──────────────────────────────┼──────────────────────────────┤
│ blog-frontend                │ 2e8e0149-db61-4883-b734-4d6… │ eecbc0fb-ee17-4d87-9b74-0ce… │
└──────────────────────────────┴──────────────────────────────┴──────────────────────────────┘
```

- #### Backwards Compatible

No breaking changes. Existing configurations automatically migrate to the new schema.


- #### Project-Specific Commands: `deploy`, `unlink`, `project`, `build-logs`, `tokens`
Run project specific commands by passing project `ID` or `Slug` as argument. Examples:

```sh
globe deploy --project="blog-frontend"
```
```sh
globe deploy --project="2e8e0149-db61-4883-b734-4d6832824ca5"
```
```sh
globe unlink --project="blog-frontend"
```
```sh
glober token list --project="blog-backend-369d"
```

Alternatively, select the project interactively:

```sh
~/Projects/OpenSource/dart-blog | on main >1 !3 ?1  globe deploy  
🔺 Select project:
❯ ◉  blog-backend-369d
  ◯  blog-frontend
  ◯  link new project +
```
## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
