### PR TITLE
fix: Resolve main entry path relative to project directory

### DIFF
--- a/packages/globe_cli/lib/src/utils/logs.dart
+++ b/packages/globe_cli/lib/src/utils/logs.dart
@@ -45,8 +45,6 @@ sealed class BuildLogEvent {
         return BuildLogs([], done: true);
       case ErrorResponse(error: final error):
         return BuildLogsError(error: '[${error.code}]: ${error.message}');
-      default:
-        throw Exception('Unknown response type');
     }
   }
   BuildLogEventType get type;


### PR DESCRIPTION
This fixes issue for mono-repos where `Globe CLI` is run from root directory, but project directory isn't root directory.

```
serverpod_project 
  - serverpod_client
  - serverpod_flutter
  - serverpod_server (actual project directory)
```

Resolving main entry should return `bin/main.dart` instead of `serverpod_server/bin/main.dart` since `serverpod_server` is already our working directory.