### PR TITLE
fix(globe_cli): Fix build-runner detection flag in CLI

### DIFF
--- a/packages/globe_cli/lib/src/utils/api.dart
+++ b/packages/globe_cli/lib/src/utils/api.dart
@@ -628,14 +628,13 @@ class FrameworkPresetOptions {
         'name': final String name,
         'entrypoint': final String entrypoint,
         'buildCommand': final String? buildCommand,
-        'buildRunnerDetection': final bool? buildRunnerDetection,
       } =>
         FrameworkPresetOptions(
           id: id,
           name: name,
           buildCommand: buildCommand,
           entrypoint: entrypoint,
-          buildRunnerDetection: buildRunnerDetection,
+          buildRunnerDetection: json['buildRunnerDetection'] as bool?,
         ),
       _ => throw const FormatException('FrameworkPresetOptions'),
     };


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Not all presets return `buildRunnerDetection` flag. 

<!--- Describe your changes in detail and provide screenshots of the output of the change if possible, e.g. screenshot of the CLI output. -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
